### PR TITLE
registration email - unenroll & display name

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -40,10 +40,8 @@ class SectionsController < ApplicationController
   def enroll
     if user_signed_in?
       if @section.enroll_user!(@user)
-        # redirect to :back since you can enroll in courses from multiple pages
-        # makes it cleaner to stay on the page you were on
         notice = "You are now enrolled in <strong>#{@course.title}</strong>"
-        redirect_to :back, notice: notice
+        redirect_to [@course, @section], notice: notice
       else
         alert = "There was a problem enrolling you in this course"
         redirect_to @course, alert: alert
@@ -75,13 +73,25 @@ class SectionsController < ApplicationController
     end
   end
 
+  def confirm_unenroll
+    if user_signed_in?
+      if @user.enrolled?(section: @section)
+        respond_with(@course, @section)
+      else
+        redirect_to @course,
+          alert: "You must be enrolled in a course to unenroll!"
+      end
+    else
+      # TODO setup a redirect to login, then resume enrollment
+      redirect_to @course, alert: "You must be logged in to drop a course"
+    end
+  end
+
   def drop
     if user_signed_in?
       if @user.enrollment_for(section: @section).destroy
-        # redirect to :back since you can drop courses from multiple pages
-        # makes it cleaner to stay on the page you were on
         notice = "You have successfully dropped <strong>#{@course.title}</strong>"
-        redirect_to :back, notice: notice
+        redirect_to [@course, @section], notice: notice
       else
         redirect_to @course, alert: "Couldn't drop user from course"
       end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -30,6 +30,7 @@ class Ability
       can :read, Section
       can :enroll, Section
       can :drop, Section
+      can :confirm_unenroll, Section
 
       if @user.instructor?
         # instructors can view rosters for sections they are teaching

--- a/app/views/sections/confirm_unenroll.html.erb
+++ b/app/views/sections/confirm_unenroll.html.erb
@@ -1,0 +1,14 @@
+<%= render partial: 'courses/title_heading',
+           locals: { course: @course, link_title: false } %>
+
+<h3>
+  Are you sure you want to drop the course, <em><%= @course.title %></em>?
+</h3>
+
+<p style="margin-top:25px">
+<%= link_to "Yes, I want to drop this course",
+            drop_course_section_path(@course, @section),
+            method: :delete, class: "btn btn-default" %>
+<%= link_to "Nevermind", course_section_path(@course, @section),
+            class: "btn btn-link" %>
+</p>

--- a/app/views/user_mailer/enroll_email.html.erb
+++ b/app/views/user_mailer/enroll_email.html.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <p><strong>Hi, <%= @user.first_name %>!</strong></p>
+    <p><strong>Hi, <%= @user.display_first %>!</strong></p>
     <p>
       You have been enrolled in the CIT Workshop: <%= @course.title %>.
     </p>
@@ -15,6 +15,11 @@
         * If this is a multi-part course, then you will receive individual
         emails for each part.
       </em>
+    </p>
+    <p>
+      <%= link_to 'Click here to unenroll from this course',
+                  confirm_unenroll_course_section_url(@course, @section),
+                  method: :delete %>
     </p>
 
     <hr />

--- a/app/views/user_mailer/enroll_email.text.erb
+++ b/app/views/user_mailer/enroll_email.text.erb
@@ -1,11 +1,16 @@
-Hi, <%= @user.first_name %>!
+Hi, <%= @user.display_first %>!
 
 You have been enrolled in the CIT Workshop: <%= @course.title %>
 
 <%= @part.date_and_time %> (<%= @part.location %>)
 
-* If this is a multi-part course, then you will receive individual emails for
-each part.
+* If this is a multi-part course, then you will receive individual emails
+for each part.
+
+To unenroll from this course, please copy and paste this link into your
+browser:
+
+<%= confirm_unenroll_course_section_url(@course, @section) %>
 
 ======================================================================
 <%= @course.title %>

--- a/app/views/user_mailer/unenroll_email.html.erb
+++ b/app/views/user_mailer/unenroll_email.html.erb
@@ -4,7 +4,7 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <p>Hi <%= @user.first_name %>,</p>
+    <p>Hi <%= @user.display_first %>,</p>
     <p>You have dropped the course, "<%= @course.title %>".   We are sorry to
       see you go.</p>
   </body>

--- a/app/views/user_mailer/unenroll_email.text.erb
+++ b/app/views/user_mailer/unenroll_email.text.erb
@@ -1,4 +1,4 @@
-Hello <%= @user.first_name %>,
+Hello <%= @user.display_first %>,
 
 You have successfully dropped the CIT Workshop "<%= @course.title %>".
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,6 +29,7 @@ Rails.application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
+  config.action_mailer.default_url_options = { :host => 'localhost:3000' }
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       member do
         post 'enroll'
         post 'enroll_user'
+        get 'confirm_unenroll'
         delete 'drop'
         delete 'drop_user'
         patch 'mark_completed'

--- a/test/controllers/sections_controller_test.rb
+++ b/test/controllers/sections_controller_test.rb
@@ -68,14 +68,11 @@ class SectionsControllerTest < ActionController::TestCase
 
   test "should enroll in course sections" do
     section = sections(:canvas113_rose)
-    # set HTTP_REFERER since the sections#enroll action uses :back as the
-    # redirect url
-    request.env["HTTP_REFERER"] = course_url(section.course)
     sign_in users(:george)
     assert_difference('section.enrollments.count') do
       post :enroll, id: section, course_id: section.course
     end
-    assert_redirected_to course_path(section.course)
+    assert_redirected_to course_section_path(section.course, section)
   end
 
   test "admins can enroll users in course sections" do
@@ -89,14 +86,11 @@ class SectionsControllerTest < ActionController::TestCase
   end
 
   test "should drop course sections" do
-    # set HTTP_REFERER since the sections#drop action uses :back as the
-    # redirect url
-    request.env["HTTP_REFERER"] = course_url(@section.course)
     sign_in users(:bill)
     assert_difference('Enrollment.count', -1) do
       delete :drop, id: @section, course_id: @section.course
     end
-    assert_redirected_to course_path(@section.course)
+    assert_redirected_to course_section_path(@section.course, @section)
   end
 
   test "admins can drop users from course sections" do


### PR DESCRIPTION
some cards from Trello to add an "unenroll" link to the email, and change the greeting to use the display name (nickname or first name) instead of always using the first name
