### PR TITLE
Remove parts when a section is removed

### DIFF
--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,6 +1,6 @@
 class Section < ActiveRecord::Base
-  has_many :enrollments
-  has_many :parts
+  has_many :enrollments, dependent: :destroy
+  has_many :parts, dependent: :destroy
   belongs_to :course
   belongs_to :instructor, class_name: 'User'
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   # devise modules
   devise :ldap_authenticatable, :database_authenticatable, :rememberable, :trackable
 
-  has_many :enrollments
+  has_many :enrollments, dependent: :destroy
   has_many :sections, foreign_key: 'instructor_id'
   has_many :courses, -> { distinct }, through: :sections
 


### PR DESCRIPTION
The Section model had a has_many relationship to a Part, but there was
no 'dependent: :destroy' option, so when a section was removed the
Part(s) were still hanging out.  This caused an error on the calendar
because it is driven by pulling all parts, and then working up through
the relations to get to sections and courses.  When a part doesn't have
a section, things get a bit wonky.

Also added 'dependent: :destroy' for the has_many :enrollments relations
on both the User and Section model.  The way I figure it, if a Section
is removed, it doesn't make any sense to have the enrollments hanging
out, same goes for when a User is removed.  They don't need their
enrollments either.
