### PR TITLE
Handle edge case for "self-paced" courses

### DIFF
--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -12,7 +12,16 @@ class Part < ActiveRecord::Base
   end
 
   def date_and_time
-    "#{starts_at.strftime("%-m/%-d/%Y %-l:%M%P")} - #{ends_at.strftime("%-l:%M%P")}"
+    # There's an edge case where occassionally there may be a section part that
+    # doesn't have a specific time, only a date.  The indicator for that will
+    # be a start time of 12:00am.  We'll handle that case and only output the
+    # date
+    # TODO: There's probably a better way to do this, but this will work for now
+    if start_time == '12:00am'
+      "#{starts_at.strftime("%-m/%-d/%Y")}"
+    else
+      "#{starts_at.strftime("%-m/%-d/%Y %-l:%M%P")} - #{ends_at.strftime("%-l:%M%P")}"
+    end
   end
 
   def start_time

--- a/test/models/part_test.rb
+++ b/test/models/part_test.rb
@@ -11,7 +11,7 @@ class PartTest < ActiveSupport::TestCase
   test "duration must be greater than zero" do
     part = Part.new(
       :location => "CIT Room7",
-      :starts_at => Time.now,
+      :starts_at => Time.current,
       :section => sections(:canvas101_carrier)
     )
 
@@ -30,7 +30,7 @@ class PartTest < ActiveSupport::TestCase
   test "duration must be an integer" do
     part = Part.new(
       :location => "CIT Room7",
-      :starts_at => Time.now,
+      :starts_at => Time.current,
       :section => sections(:canvas101_carrier)
     )
 
@@ -45,12 +45,23 @@ class PartTest < ActiveSupport::TestCase
   test "ends_at time is starts_at time plus duration" do
     part = Part.new(
       :location => 'CIT Room 7',
-      :starts_at => Time.now,
+      :starts_at => Time.current,
       :duration => 90,
       :section => sections(:canvas101_carrier)
     )
 
-    assert_equal Time.at(part.starts_at + (part.duration * 60)),
+    assert_equal Time.zone.at(part.starts_at + (part.duration * 60)),
                  part.ends_at
+  end
+
+  test "when start time is midnight only display date" do
+    part = Part.new(
+      :location => 'CIT Room 7',
+      :starts_at => Time.current.at_beginning_of_day,
+      :duration => 90,
+      :section => sections(:canvas101_carrier)
+    )
+
+    assert_equal "#{part.starts_at.strftime("%-m/%-d/%Y")}", part.date_and_time
   end
 end


### PR DESCRIPTION
Some courses are self-paced or asyncronous, where there is no specific
time.  To handle these, for now we are just keying them in with a start
time of 12:00am, and using that to trigger a "date only".
