### PR TITLE
Add validations on Course.short_title

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,8 +2,12 @@ class Course < ActiveRecord::Base
   has_many :sections, dependent: :destroy
   has_many :enrollments, through: :sections
 
-  validates :title, :description, :course_number, presence: true
+  validates :title, :short_title, :description, :course_number,
+            :summary, presence: true
   validates :title, :course_number, uniqueness: true
+  validates :short_title, length: { maximum: 30 }
+
+  before_validation :ensure_course_has_short_title
 
   def description_html
     markdown.render(description).html_safe
@@ -26,6 +30,13 @@ class Course < ActiveRecord::Base
   def instructors
     sections.collect { |section| section.instructor.display_name }.uniq
   end
+
+
+  protected
+    def ensure_course_has_short_title
+      self.short_title = title if short_title.blank?
+    end
+
 
   private
     def markdown

--- a/app/views/courses/_form.html.erb
+++ b/app/views/courses/_form.html.erb
@@ -32,10 +32,12 @@
 
   <div class="form-group<%= " has-error" if @course.errors[:short_title].any? %>">
     <%= f.label :short_title, class: 'control-label' %>
-    <%= f.text_field :short_title, class: 'form-control' %>
+    <%= f.text_field :short_title, class: 'form-control', maxlength: 30 %>
     <span class="help-block">
-      The short title will be displayed whenever a shortened version of the
-      title is needed, i.e. displaying courses on the calendar.
+      The short title (maximum 30 characters) will be displayed whenever a
+      shortened version of the title is needed, i.e. displaying courses on
+      the calendar.
+    </span>
   </div>
 
   <div class="form-group<%= " has-error" if @course.errors[:summary].any? %>">

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -6,6 +6,7 @@ class CoursesControllerTest < ActionController::TestCase
     @update = {
       title: "Teaching Monkeys to Sing",
       course_number: 'CITTEST',
+      summary: "Monkeys can sing too",
       description: "Singing monkeys are the awesome!",
       duration: 30
     }

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -6,6 +6,8 @@ class CourseTest < ActiveSupport::TestCase
     assert course.invalid?
     assert course.errors[:course_number].any?
     assert course.errors[:title].any?
+    assert course.errors[:short_title].any?
+    assert course.errors[:summary].any?
     assert course.errors[:description].any?
   end
 
@@ -35,5 +37,29 @@ class CourseTest < ActiveSupport::TestCase
   test "duration is pulled from the first section" do
     course = courses(:canvas101)
     assert_equal course.sections.first.duration, course.duration
+  end
+
+  test "short_title is set to title value if not present" do
+    course = Course.new(
+      title: 'Testing w/Rails 101',
+      course_number: 'TEST001',
+      description: 'Just a test course :)',
+      summary: 'Test with Rails'
+    )
+    course.save
+    assert_equal course.title, course.short_title
+  end
+
+  test "short_title is 30 chars max" do
+    course = Course.new(
+      title: 'Testing w/Rails 101',
+      short_title: 'This title is not short and should fail validation',
+      course_number: 'TEST001',
+      description: 'Just a test course :)',
+      summary: 'Test with Rails'
+    )
+    assert course.invalid?
+    assert_equal ["is too long (maximum is 30 characters)"],
+                 course.errors[:short_title]
   end
 end


### PR DESCRIPTION
There were no validations at all on the :short_title attribute for a
Course.  Added a presence validation, as well as a length validation to
ensure a maximum length of 30 chars.

For convenince, a :before_validation callback was added to set
:short_title = :title if there is no :short_title.

As I was adding tests for these I also noticed that the :summary
attribute didn't have any validations either, so added a presence
validation on that field as well.
