### PR TITLE
Don't show courses in the past

### DIFF
--- a/app/assets/stylesheets/courses.css.scss
+++ b/app/assets/stylesheets/courses.css.scss
@@ -22,4 +22,7 @@
   .admin-actions {
     background-color: #f8f8f8;
   }
+  .past-course-list {
+    margin-top: 36px;
+  }
 }

--- a/app/controllers/calendar_controller.rb
+++ b/app/controllers/calendar_controller.rb
@@ -1,7 +1,7 @@
 class CalendarController < ApplicationController
   def index
     @user = current_user
-    @parts = Part.all
+    @parts = Part.current.all
 
     @start_date ||= (params[:start_date] || Time.current).to_date
     @parts_this_month = @parts.select do |part|

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -8,6 +8,20 @@ class CoursesController < ApplicationController
 
   def index
     @courses = Course.order(:title)
+
+    # split the courses into two lists, one for "current" courses
+    # and one for "past" courses.  (Only admins will be able to see
+    # the list of "past" courses.)
+    @current_courses = []
+    @past_courses = []
+    @courses.each do |course|
+      if course.current?
+        @current_courses << course
+      else
+        @past_courses << course
+      end
+    end
+
     respond_with(@courses)
   end
 

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -26,7 +26,8 @@ class CoursesController < ApplicationController
   end
 
   def show
-    @available_sections = @course.sections.sort_by { |s| s.starts_at }
+    @available_sections = @course.current_sections.sort_by { |s| s.starts_at }
+    @past_sections = @course.past_sections.sort_by { |s| s.starts_at }
     respond_with(@course)
   end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -11,7 +11,8 @@ class SectionsController < ApplicationController
   respond_to :html, :json
 
   def index
-    @available_sections = @course.sections.sort_by { |s| s.starts_at }
+    @available_sections = @course.current_sections.sort_by { |s| s.starts_at }
+    @past_sections = @course.past_sections.sort_by { |s| s.starts_at }
     respond_with(@course, @sections)
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,6 @@ class UsersController < ApplicationController
 
   def show
     @user ||= current_user
-    @courses = Course.all # this is temporary stub data
     respond_with(@user)
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -45,10 +45,15 @@ class Course < ActiveRecord::Base
   end
 
   def current?
-    sections.each do |section|
-      return true if section.current?
-    end
-    false
+    current_sections.any?
+  end
+
+  def current_sections
+    sections.select { |s| s.current? }
+  end
+
+  def past_sections
+    sections.reject { |s| s.current? }
   end
 
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -44,6 +44,13 @@ class Course < ActiveRecord::Base
     sections.collect { |section| section.instructor.display_name }.uniq
   end
 
+  def current?
+    sections.each do |section|
+      return true if section.current?
+    end
+    false
+  end
+
 
   protected
     def ensure_course_has_short_title

--- a/app/models/part.rb
+++ b/app/models/part.rb
@@ -10,6 +10,10 @@ class Part < ActiveRecord::Base
           DateTime.current.at_end_of_day.advance(days: 3))
   }
 
+  scope :current, -> {
+    where('starts_at >= ?', DateTime.current.at_beginning_of_day)
+  }
+
   validates :location, :starts_at, :duration, presence: true
   validates :duration, numericality: {only_integer: true, greater_than: 0}
 
@@ -23,7 +27,7 @@ class Part < ActiveRecord::Base
     # be a start time of 12:00am.  We'll handle that case and only output the
     # date
     # TODO: There's probably a better way to do this, but this will work for now
-    if online? 
+    if online?
       "#{starts_at.strftime("%-m/%-d/%Y")}"
     else
       "#{starts_at.strftime("%-m/%-d/%Y %-l:%M%P")} - #{ends_at.strftime("%-l:%M%P")}"
@@ -36,5 +40,9 @@ class Part < ActiveRecord::Base
 
   def online?
     start_time == '12:00am'
+  end
+
+  def current?
+    starts_at >= DateTime.current.at_beginning_of_day
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -47,13 +47,17 @@ class Section < ActiveRecord::Base
   end
 
   def duration
-    return nil unless parts.any?
+    return nil unless parts.current.any?
     # section duration is the sum of all its parts
-    parts.inject(0) { |duration, part| duration + part.duration }
+    parts.current.inject(0) { |duration, part| duration + part.duration }
   end
 
   def starts_at
-    return nil unless parts.any?
-    parts.order(:starts_at).first.starts_at
+    return nil unless parts.current.any?
+    parts.current.order(:starts_at).first.starts_at
+  end
+
+  def current?
+    parts.current.any?
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -47,11 +47,13 @@ class Section < ActiveRecord::Base
   end
 
   def duration
+    return nil unless parts.any?
     # section duration is the sum of all its parts
     parts.inject(0) { |duration, part| duration + part.duration }
   end
 
   def starts_at
+    return nil unless parts.any?
     parts.order(:starts_at).first.starts_at
   end
 end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -47,17 +47,23 @@ class Section < ActiveRecord::Base
   end
 
   def duration
-    return nil unless parts.current.any?
-    # section duration is the sum of all its parts
-    parts.current.inject(0) { |duration, part| duration + part.duration }
+    parts.inject(0) { |duration, part| duration + part.duration }
   end
 
   def starts_at
-    return nil unless parts.current.any?
-    parts.current.order(:starts_at).first.starts_at
+    return nil unless parts.any?
+    parts.order(:starts_at).first.starts_at
   end
 
   def current?
-    parts.current.any?
+    current_parts.any?
+  end
+
+  def current_parts
+    parts.select { |p| p.current? }
+  end
+
+  def past_parts
+    parts.reject { |p| p.current? }
   end
 end

--- a/app/views/courses/_course.html.erb
+++ b/app/views/courses/_course.html.erb
@@ -1,0 +1,32 @@
+<div class="course-row">
+  <h3 class="title">
+    <%= render partial: 'icons', locals: { course: course } %>
+    <%= link_to course.title, course %>
+  </h3>
+  <% if course.summary %>
+    <div class="summary">
+      <%= course.summary %>
+    </div>
+  <% end %>
+  <div class="details">
+    <ul class="list-inline">
+      <% if course.duration %>
+      <li>
+        <strong>Duration:</strong> <%= course.duration_in_words %>
+      </li>
+      <% end %>
+      <% if course.multi_session? %>
+      <li>
+        <strong>Multiple Sessions</strong>
+      </li>
+      <% end %>
+      <% if course.instructors.any? %>
+      <li>
+        <strong>Instructed by:</strong>
+        <%= course.instructors.to_sentence %>
+      </li>
+      <% end %>
+    </ul>
+  </div>
+  <%= render :partial => 'admin_actions', :locals => { :course => course } %>
+</div>

--- a/app/views/courses/_past_sections.html.erb
+++ b/app/views/courses/_past_sections.html.erb
@@ -1,0 +1,11 @@
+<div class="panel panel-default panel-with-sections">
+  <div class="panel-heading">
+    <h3 class="panel-title">
+      Past sections
+      <small>Archive sections that are no longer current</small>
+    </h3>
+  </div>
+  <div class="panel-body">
+    <%= render @past_sections %>
+  </div>
+</div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -20,11 +20,13 @@
 <% end %>
 
 <% if @past_courses.any? and can?(:view_past_courses, Course)  %>
-<h2>
-  Past Courses
-  <small>These are courses that have no current sections or parts</small>
-</h2>
-<div class="panel panel-default">
+<div class="panel panel-default past-course-list">
+  <div class="panel-heading">
+    <h2 class="panel-title">
+      Past Courses
+      <small>These are courses that have no current sections</small>
+    </h2>
+  </div>
   <div class="panel-body">
     <%= render @past_courses %>
   </div>

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 </div>
 
-<% if @courses.empty? %>
+<% if @current_courses.empty? %>
 <p>
   There are no courses available at this time.
   <% if can? :create, Course %>
@@ -16,38 +16,17 @@
 <p>
 <% else %>
   <%= render 'shared/icon_legend' %>
-  <% @courses.each do |course| %>
-  <div class="course-row">
-    <h3 class="title">
-      <%= render partial: 'icons', locals: { course: course } %>
-      <%= link_to course.title, course %>
-    </h3>
-    <% if course.summary %>
-      <div class="summary">
-        <%= course.summary %>
-      </div>
-    <% end %>
-    <div class="details">
-      <ul class="list-inline">
-        <% if course.duration %>
-        <li>
-          <strong>Duration:</strong> <%= course.duration_in_words %>
-        </li>
-        <% end %>
-        <% if course.multi_session? %>
-        <li>
-          <strong>Multiple Sessions</strong>
-        </li>
-        <% end %>
-        <% if course.instructors.any? %>
-        <li>
-          <strong>Instructed by:</strong>
-          <%= course.instructors.to_sentence %>
-        </li>
-        <% end %>
-      </ul>
-    </div>
-    <%= render :partial => 'admin_actions', :locals => { :course => course } %>
+  <%= render @current_courses %>
+<% end %>
+
+<% if @past_courses.any? and can?(:view_past_courses, Course)  %>
+<h2>
+  Past Courses
+  <small>These are courses that have no current sections or parts</small>
+</h2>
+<div class="panel panel-default">
+  <div class="panel-body">
+    <%= render @past_courses %>
   </div>
-  <% end %>
+</div>
 <% end %>

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -27,3 +27,6 @@
 </article>
 
 <%= render "available_sections" %>
+<% if @past_sections.any? and can?(:view_past_sections, Course) %>
+  <%= render "past_sections" %>
+<% end %>

--- a/app/views/sections/_section.html.erb
+++ b/app/views/sections/_section.html.erb
@@ -20,7 +20,10 @@
   <%= render partial: 'parts/part', collection: section.parts, layout: 'parts/panel_body_section_row' %>
 
   <div class="actions">
-    <%= render partial: 'sections/action', locals: {user: @user, section: section}  %>
+    <% if section.current? %>
+      <%= render partial: 'sections/action',
+                 locals: {user: @user, section: section}  %>
+    <% end %>
 
     <% if user_signed_in? && (can?(:update, section) || can?(:destroy, section)) %>
       <% if can? :update, section %>

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -2,3 +2,6 @@
                                                        link_title: true } %>
 
 <%= render 'courses/available_sections' %>
+<% if @past_sections.any? and can?(:view_past_sections, Course) %>
+  <%= render "courses/past_sections" %>
+<% end %>

--- a/app/views/users/_instructor_sections.html.erb
+++ b/app/views/users/_instructor_sections.html.erb
@@ -19,8 +19,12 @@
     <% @user.sections.each do |section| %>
       <tr>
         <td><%= link_to section.course.title, section.course %></td>
-        <td><%= section.parts.first.date_and_time %></td>
-        <td><%= section.parts.first.location %></td>
+        <% if section.parts.any? %>
+          <td><%= section.parts.first.date_and_time %></td>
+          <td><%= section.parts.first.location %></td>
+        <% else %>
+          <td colspan="2">(No parts found for this section)</td>
+        <% end %>
         <td class="text-right">
           <%= link_to course_section_path(section.course, section),
                       :class => 'btn btn-default btn-xs' do %>

--- a/test/fixtures/parts.yml
+++ b/test/fixtures/parts.yml
@@ -1,19 +1,29 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+#
+# The fixtures for the parts are commented out here since they have specific
+# dates in them, and some of the tests are dependent on certain date values.
+# Which means that if any tests depend on these fixtures, they may break
+# simply due to the fact that time has passes since the fixtures were updated,
+# and have no relevance on the test actually breaking.
+#
+# So I think a better workflow is to not use fixtures for parts, but rather
+# create parts in the tests when they are needed, with relative date values
+# so the tests will be consistent.
 
-canvas101_carrier_part1:
-  section: canvas101_carrier
-  location: Carrier Library Room 37
-  starts_at: 2014-10-08 14:00:00
-  duration: 60
+#canvas101_carrier_part1:
+#  section: canvas101_carrier
+#  location: Carrier Library Room 37
+#  starts_at: 2015-02-21 14:00:00
+#  duration: 60
 
-canvas101_carrier_part2:
-  section: canvas101_carrier
-  location: Carrier Library Room 37
-  starts_at: 2014-10-12 09:00:00
-  duration: 60
+#canvas101_carrier_part2:
+#  section: canvas101_carrier
+#  location: Carrier Library Room 37
+#  starts_at: 2015-02-23 14:00:00
+#  duration: 60
 
-canvas113_rose_part1:
-  section: canvas113_rose
-  location: Rose Library Room 5308
-  starts_at: 2014-10-08 09:00:00
-  duration: 90
+#canvas113_rose_part1:
+#  section: canvas113_rose
+#  location: Rose Library Room 5308
+#  starts_at: 2015-02-15 09:00:00
+#  duration: 90

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -75,4 +75,34 @@ class CourseTest < ActiveSupport::TestCase
     assert_equal ["is too long (maximum is 30 characters)"],
                  course.errors[:short_title]
   end
+
+  test "course is not current when it has no sections" do
+    course = Course.new(
+      title: 'Testing w/Rails 101',
+      course_number: 'TEST001',
+      description: 'Just a test course :)',
+      summary: 'Test with Rails'
+    )
+    assert_not course.current?
+  end
+
+  test "course is not current when it has no current sections" do
+    # the fixtures don't add any parts to the sections, so the
+    # :canvas101 course fixture should just have empty sections,
+    # which should not be 'current'
+    course = courses(:canvas101)
+    assert_not course.current?
+  end
+
+  test "course is current when it has current sections" do
+    course = courses(:canvas101)
+    # need to add a part so it can be current
+    Part.create!(
+      location: 'Room 7',
+      starts_at: Time.current,
+      duration: 30,
+      section: course.sections.first
+    )
+    assert course.current?
+  end
 end

--- a/test/models/course_test.rb
+++ b/test/models/course_test.rb
@@ -41,6 +41,14 @@ class CourseTest < ActiveSupport::TestCase
 
   test "duration_in_words makes long durations readable" do
     course = courses(:canvas113)
+    # add a part to the course so we can get a duration
+    Part.create!(
+      location: 'Room 7',
+      starts_at: Time.current,
+      duration: 90,
+      section: course.sections.first
+    )
+
     assert_equal "1h 30m", course.duration_in_words
   end
 

--- a/test/models/part_test.rb
+++ b/test/models/part_test.rb
@@ -10,9 +10,9 @@ class PartTest < ActiveSupport::TestCase
 
   test "duration must be greater than zero" do
     part = Part.new(
-      :location => "CIT Room7",
-      :starts_at => Time.current,
-      :section => sections(:canvas101_carrier)
+      location: "CIT Room7",
+      starts_at: Time.current,
+      section: sections(:canvas101_carrier)
     )
 
     part.duration = -1
@@ -29,9 +29,9 @@ class PartTest < ActiveSupport::TestCase
 
   test "duration must be an integer" do
     part = Part.new(
-      :location => "CIT Room7",
-      :starts_at => Time.current,
-      :section => sections(:canvas101_carrier)
+      location: "CIT Room7",
+      starts_at: Time.current,
+      section: sections(:canvas101_carrier)
     )
 
     part.duration = 0.01
@@ -44,10 +44,10 @@ class PartTest < ActiveSupport::TestCase
 
   test "ends_at time is starts_at time plus duration" do
     part = Part.new(
-      :location => 'CIT Room 7',
-      :starts_at => Time.current,
-      :duration => 90,
-      :section => sections(:canvas101_carrier)
+      location: 'CIT Room 7',
+      starts_at: Time.current,
+      duration: 90,
+      section: sections(:canvas101_carrier)
     )
 
     assert_equal Time.zone.at(part.starts_at + (part.duration * 60)),
@@ -56,12 +56,75 @@ class PartTest < ActiveSupport::TestCase
 
   test "when start time is midnight only display date" do
     part = Part.new(
-      :location => 'CIT Room 7',
-      :starts_at => Time.current.at_beginning_of_day,
-      :duration => 90,
-      :section => sections(:canvas101_carrier)
+      location: 'CIT Room 7',
+      starts_at: Time.current.at_beginning_of_day,
+      duration: 90,
+      section: sections(:canvas101_carrier)
     )
 
     assert_equal "#{part.starts_at.strftime("%-m/%-d/%Y")}", part.date_and_time
+  end
+
+  test "parts starting in the past are not current" do
+    part = Part.new(
+      location: 'CIT Room 7',
+      starts_at: Time.current.advance(days: -21),
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+    assert_not part.current?
+  end
+
+  test "parts starting on the current day are current" do
+    part = Part.new(
+      location: 'CIT Room 7',
+      starts_at: Time.current,
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+    assert part.current?
+  end
+
+  test "parts starting in the future are not considered current" do
+    part = Part.new(
+      location: 'CIT Room 7',
+      starts_at: Time.current.advance(days: 21),
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+    assert part.current?
+  end
+
+  test "current scope only returns current parts" do
+    # create a part in the past
+    past = Part.create!(
+      location: 'Room7',
+      starts_at: Time.current.advance(days: -2),
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+    # create a part in the present
+    present = Part.create!(
+      location: 'Room7',
+      starts_at: Time.current,
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+    # create a part in the future
+    future = Part.create!(
+      location: 'Room7',
+      starts_at: Time.current.advance(days: 2),
+      duration: 60,
+      section: sections(:canvas101_carrier)
+    )
+
+    parts = Part.current
+    assert_equal 2, parts.length
+    assert_not_includes parts, past,
+      "'current' scope shouldn't include past parts"
+    assert_includes parts, present,
+      "'current' scope should inclue present parts"
+    assert_includes parts, future,
+      "'current' scope should inclue future parts"
   end
 end

--- a/test/models/section_test.rb
+++ b/test/models/section_test.rb
@@ -60,20 +60,57 @@ class SectionTest < ActiveSupport::TestCase
   end
 
   test "duration is the sum of its parts" do
-    section = Section.new(
-      :section_number => 'CIT999',
-      :instructor => users(:instructor),
-      :course => courses(:canvas101),
-      :parts_attributes => [{
-        :location => "CIT Room7",
-        :starts_at => Time.now,
-        :duration => 45
+    section = Section.create!(
+      section_number: 'CIT999',
+      instructor: users(:instructor),
+      seats: 6,
+      course: courses(:canvas101),
+      parts_attributes: [{
+        location: "CIT Room7",
+        starts_at: Time.current,
+        duration: 45
       },{
-        :location => "CIT Room7",
-        :starts_at => Time.now.advance(:weeks => 1),
-        :duration => 45
+        location: "CIT Room7",
+        starts_at: Time.current.advance(:weeks => 1),
+        duration: 45
       }]
     )
     assert_equal 90, section.duration
+  end
+
+  test "section isn't current if doesn't have any parts" do
+    section = sections(:canvas101_carrier)
+    assert_not section.current?
+  end
+
+  test "section isn't current if it doesn't have any current parts" do
+    section = sections(:canvas101_carrier)
+    # create a past part in the database
+    Part.create!(
+      location: 'Room7',
+      starts_at: Time.current.advance(days: -1),
+      duration: 30,
+      section: section
+    )
+    assert_not section.current?
+  end
+
+  test "section is current if it contains at least one current part" do
+    section = sections(:canvas101_carrier)
+    # create a past part in the database
+    Part.create!(
+      location: 'Room7',
+      starts_at: Time.current.advance(days: -1),
+      duration: 30,
+      section: section
+    )
+    # create a future part in the database
+    Part.create!(
+      location: 'Room7',
+      starts_at: Time.current.advance(days: 1),
+      duration: 30,
+      section: section
+    )
+    assert section.current?
   end
 end


### PR DESCRIPTION
As we are moving into the second semester of using this workshop app, there are now courses which were from the past semester that shouldn't show for this semester.  So what we really need to do is implement some filtering so only current courses are displayed.

Here's the logic:

- A course is current _if and only if_ it contains at least one current section
- A section is current _if and only if_ it contains at least one current part
- A part is current _if and only if_ it has a `:starts_at` value that is greater than or equal to the current date
