### PR TITLE
Roster management extras

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -143,7 +143,19 @@ class SectionsController < ApplicationController
       user.enrollment_for(section: @section).no_show!
       notice = "<strong>#{user.display_name}</strong>" \
                " is marked as a 'no show' for <strong>#{@course.title}</strong>"
-      redirect_to [@course, @section], alert: alert
+      redirect_to [@course, @section], notice: notice
+    end
+  end
+
+  def reset_status
+    redirect_to [@course, @section] unless params[:user_id].present?
+
+    user = User.find(params[:user_id])
+    if user
+      user.enrollment_for(section: @section).reset_status!
+      notice = "<strong>#{user.display_name}'s</strong>" \
+               " status for <strong>#{@course.title}</strong> has been reset"
+      redirect_to [@course, @section], notice: notice
     end
   end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -135,6 +135,18 @@ class SectionsController < ApplicationController
     end
   end
 
+  def mark_no_show
+    redirect_to [@course, @section] unless params[:user_id].present?
+
+    user = User.find(params[:user_id])
+    if user
+      user.enrollment_for(section: @section).no_show!
+      notice = "<strong>#{user.display_name}</strong>" \
+               " is marked as a 'no show' for <strong>#{@course.title}</strong>"
+      redirect_to [@course, @section], alert: alert
+    end
+  end
+
 
   private
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -44,6 +44,8 @@ class Ability
         can :drop_user, Section, instructor_id: @user.id
         # and mark folks as having completed a section
         can :mark_completed, Section, instructor_id: @user.id
+        # and mark folks as a no-show for a section
+        can :mark_no_show, Section, instructor_id: @user.id
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,8 @@ class Ability
         can :mark_completed, Section, instructor_id: @user.id
         # and mark folks as a no-show for a section
         can :mark_no_show, Section, instructor_id: @user.id
+        # and and reset the state
+        can :reset_state, Section, instructor_id: @user.id
       end
     end
 

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -34,6 +34,12 @@ class Enrollment < ActiveRecord::Base
     no_show
   end
 
+  def reset_status!
+    self.no_show = false
+    self.completed_at = nil
+    save
+  end
+
   def section_full?
     section.is_full?
   end

--- a/app/models/enrollment.rb
+++ b/app/models/enrollment.rb
@@ -20,7 +20,18 @@ class Enrollment < ActiveRecord::Base
 
   def completed!
     self.completed_at = Time.current unless completed?
+    self.no_show = false
     save
+  end
+
+  def no_show!
+    self.no_show = true
+    self.completed_at = nil
+    save
+  end
+
+  def no_show?
+    no_show
   end
 
   def section_full?

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -66,4 +66,8 @@ class Section < ActiveRecord::Base
   def past_parts
     @past_parts ||= parts.reject { |p| p.current? }
   end
+
+  def roster
+    enrollments.active.sort { |a,b| a.user.last_name <=> b.user.last_name }
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -67,13 +67,13 @@ class User < ActiveRecord::Base
 
   def enrolled?(options = {})
     enrollment = enrollment_for(options)
-    enrollment.present? && !enrollment.completed?
+    enrollment.present? && !(enrollment.completed? || enrollment.no_show?)
   end
 
   def waiting?(options = {})
     options[:scope] = :waiting
     enrollment = enrollment_for(options)
-    enrollment.present? && !enrollment.completed?
+    enrollment.present?
   end
 
   def enrollment_for(options = {})
@@ -110,7 +110,10 @@ class User < ActiveRecord::Base
   end
 
   def current_enrollments
-    enrollments.select { |enrollment| !enrollment.completed? }
+    enrollments.select do |enrollment|
+      enrollment.section.current? &&
+        !(enrollment.completed? || enrollment.no_show?)
+    end
   end
 
   def completed_enrollments

--- a/app/views/sections/_course_roster.html.erb
+++ b/app/views/sections/_course_roster.html.erb
@@ -30,11 +30,37 @@
               <span class="glyphicon glyphicon-ok"></span>
               <strong>Completed</strong>
             </span>
+            <% if can? :reset_status, @section %>
+              <div class="action-form">
+                <%= form_tag reset_status_course_section_path, method: :patch,
+                      role: 'form' do |f| %>
+                  <%= hidden_field_tag :user_id, enrollment.user.id %>
+                  <%= button_tag type: :submit, title: "Reset status",
+                        data: { toggle: 'tooltip', placement: 'top' },
+                        class: 'btn btn-link btn-sm' do %>
+                      (reset)
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
           <% elsif enrollment.no_show? %>
             <span class="mark-no-show">
               <span class="glyphicon glyphicon-eye-close"></span>
               <strong>No Show</strong>
             </span>
+            <% if can? :reset_status, @section %>
+              <div class="action-form">
+                <%= form_tag reset_status_course_section_path, method: :patch,
+                      role: 'form' do |f| %>
+                  <%= hidden_field_tag :user_id, enrollment.user.id %>
+                  <%= button_tag type: :submit, title: "Reset status",
+                        data: { toggle: 'tooltip', placement: 'top' },
+                        class: 'btn btn-link btn-sm' do %>
+                      (reset)
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
           <% else %>
             <% if can? :drop_user, @section %>
               <div class="action-form">

--- a/app/views/sections/_course_roster.html.erb
+++ b/app/views/sections/_course_roster.html.erb
@@ -17,7 +17,7 @@
         </tr>
       </thead>
       <tbody>
-      <% @section.enrollments.active.each do |enrollment| %>
+      <% @section.roster.each do |enrollment| %>
         <tr>
           <td><%= enrollment.user.display_name %></td>
           <td><%= enrollment.user.employee_id %></td>
@@ -29,6 +29,11 @@
             <span class="mark-completed">
               <span class="glyphicon glyphicon-ok"></span>
               <strong>Completed</strong>
+            </span>
+          <% elsif enrollment.no_show? %>
+            <span class="mark-no-show">
+              <span class="glyphicon glyphicon-eye-close"></span>
+              <strong>No Show</strong>
             </span>
           <% else %>
             <% if can? :drop_user, @section %>
@@ -53,6 +58,19 @@
                         data: { toggle: 'tooltip', placement: 'top' },
                         class: 'btn btn-default btn-sm' do %>
                     <span class="glyphicon glyphicon-ok mark-completed"></span>
+                  <% end %>
+                <% end %>
+              </div>
+            <% end %>
+            <% if can? :mark_no_show, @section %>
+              <div class="action-form">
+                <%= form_tag mark_no_show_course_section_path, method: :patch,
+                      role: 'form' do |f| %>
+                  <%= hidden_field_tag :user_id, enrollment.user.id %>
+                  <%= button_tag type: :submit, title: "Mark no show",
+                        data: { toggle: 'tooltip', placement: 'top' },
+                        class: 'btn btn-default btn-sm' do %>
+                    <span class="glyphicon glyphicon-eye-close mark-no-show"></span>
                   <% end %>
                 <% end %>
               </div>

--- a/app/views/sections/_course_roster.html.erb
+++ b/app/views/sections/_course_roster.html.erb
@@ -10,9 +10,10 @@
           <th>Name</th>
           <th>Employee ID</th>
           <th>Email</th>
-          <th>Phone</th>
+          <th class="hidden-print">Phone</th>
           <th>Department</th>
-          <th class="actions"></th>
+          <th class="actions hidden-print"></th>
+          <th class="visible-print">Initials</th>
         </tr>
       </thead>
       <tbody>
@@ -21,9 +22,9 @@
           <td><%= enrollment.user.display_name %></td>
           <td><%= enrollment.user.employee_id %></td>
           <td><%= enrollment.user.email %></td>
-          <td><%= enrollment.user.phone_number %></td>
+          <td class="hidden-print"><%= enrollment.user.phone_number %></td>
           <td><%= enrollment.user.department %></td>
-          <td class="actions">
+          <td class="actions hidden-print">
           <% if enrollment.completed? %>
             <span class="mark-completed">
               <span class="glyphicon glyphicon-ok"></span>
@@ -31,7 +32,7 @@
             </span>
           <% else %>
             <% if can? :drop_user, @section %>
-              <div class="action-form hidden-print">
+              <div class="action-form">
                 <%= form_tag drop_user_course_section_path, method: :delete,
                       role: 'form' do |f| %>
                   <%= hidden_field_tag :user_id, enrollment.user.id %>
@@ -44,7 +45,7 @@
               </div>
             <% end %>
             <% if can? :mark_completed, @section %>
-              <div class="action-form hidden-print">
+              <div class="action-form">
                 <%= form_tag mark_completed_course_section_path, method: :patch,
                       role: 'form' do |f| %>
                   <%= hidden_field_tag :user_id, enrollment.user.id %>
@@ -58,6 +59,7 @@
             <% end %>
           <% end %>
           </td>
+          <td class="visible-print"></td>
         </tr>
       <% end %>
       </tbody>

--- a/app/views/sections/show.html.erb
+++ b/app/views/sections/show.html.erb
@@ -18,9 +18,13 @@
            locals: { course: @course, link_title: true } %>
 
 <div class="summary">
-  <ul class="list-unstyled">
+  <ul class="list-inline">
     <li>
-      <strong>Section Number:</strong>
+      <strong>Course:</strong>
+      <%= @section.course.course_number %>
+    </li>
+    <li>
+      <strong>Section:</strong>
       <%= @section.section_number %>
     </li>
 
@@ -29,7 +33,7 @@
       <%= @section.instructor.display_name %>
     </li>
 
-    <li>
+    <li class="hidden-print">
       <% if @section.is_full? %>
         <span class="label label-danger">Section full</span>
       <% else %>
@@ -53,5 +57,7 @@
 
 <% if can? :view_enrollments, @section %>
   <%= render 'course_roster' %>
-  <%= render 'wait_list' if @section.is_full? %>
+  <div class="hidden-print">
+    <%= render 'wait_list' if @section.is_full? %>
+  </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         delete 'drop'
         delete 'drop_user'
         patch 'mark_completed'
+        patch 'mark_no_show'
         post 'wait_list'
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         delete 'drop_user'
         patch 'mark_completed'
         patch 'mark_no_show'
+        patch 'reset_status'
         post 'wait_list'
       end
     end

--- a/db/migrate/20150406200450_add_no_show_to_enrollments.rb
+++ b/db/migrate/20150406200450_add_no_show_to_enrollments.rb
@@ -1,0 +1,5 @@
+class AddNoShowToEnrollments < ActiveRecord::Migration
+  def change
+    add_column :enrollments, :no_show, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141216205627) do
+ActiveRecord::Schema.define(version: 20150406200450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20141216205627) do
     t.datetime "updated_at"
     t.uuid     "ical_event_uid"
     t.boolean  "waiting",        default: false
+    t.boolean  "no_show",        default: false
   end
 
   create_table "parts", force: true do |t|

--- a/test/models/enrollment_test.rb
+++ b/test/models/enrollment_test.rb
@@ -15,10 +15,34 @@ class EnrollmentTest < ActiveSupport::TestCase
     assert_equal ["has already been enrolled in this section"], enrollment.errors[:user]
   end
 
+  test "enrollments can be marked as completed" do
+    enrollment = enrollments(:george_canvas101_carrier)
+    enrollment.completed!
+    assert enrollment.completed?
+  end
+
   test "enrollments can be marked as a no-show" do
     enrollment = enrollments(:george_canvas101_carrier)
     enrollment.no_show!
     assert enrollment.no_show?
+    assert_not enrollment.completed?
+  end
+
+  test "enrollment status can be reset" do
+    enrollment = enrollments(:george_canvas101_carrier)
+
+    # mark enrollment as no-show
+    enrollment.no_show!
+    assert enrollment.no_show?
+    # now reset it and make sure it got reset
+    enrollment.reset_status!
+    assert_not enrollment.no_show?
+
+    # mark enrollment as completed
+    enrollment.completed!
+    assert enrollment.completed?
+    # and reset it
+    enrollment.reset_status!
     assert_not enrollment.completed?
   end
 end

--- a/test/models/enrollment_test.rb
+++ b/test/models/enrollment_test.rb
@@ -14,4 +14,11 @@ class EnrollmentTest < ActiveSupport::TestCase
     assert enrollment.invalid?
     assert_equal ["has already been enrolled in this section"], enrollment.errors[:user]
   end
+
+  test "enrollments can be marked as a no-show" do
+    enrollment = enrollments(:george_canvas101_carrier)
+    enrollment.no_show!
+    assert enrollment.no_show?
+    assert_not enrollment.completed?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,8 +2,16 @@ require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
   test "user knows if they are enrolled in a course" do
+    # add an active part to the course
+    course = courses(:canvas101)
+    Part.create!(
+      section: course.sections.first,
+      starts_at: Time.current,
+      duration: 20,
+      location: 'rm7'
+    )
     user = users(:george)
-    assert user.enrolled? :course => courses(:canvas101)
+    assert user.enrolled? course: course
   end
 
   test "user provides enrollment for course if enrolled" do
@@ -45,5 +53,20 @@ class UserTest < ActiveSupport::TestCase
     )
     assert user
     assert user.id.present?
+  end
+
+  test "user is not enrolled if they were a no show" do
+    course = courses(:canvas101)
+    Part.create!(
+      section: course.sections.first,
+      starts_at: Time.current,
+      duration: 25,
+      location: 'rm7'
+    )
+    user = users(:george)
+    enrollment = user.enrollment_for course: course
+    enrollment.no_show!
+    assert_not user.enrolled? course: course
+    assert_not_includes user.current_enrollments, enrollment
   end
 end


### PR DESCRIPTION
A couple of items from our backlog relating to roster management:

- [x] Add course number and initials column to roster (https://trello.com/c/a0KxXfk7)
- [x] Reset status (clear completed and no-show) (https://trello.com/c/00UWtQdN)
- [x] Add "no-show" participant status for courses (https://trello.com/c/Fbc7yeQS)