### PR TITLE
Fix enrollment errors and dupes

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -65,11 +65,16 @@ class SectionsController < ApplicationController
   def enroll_user
     if params[:username].empty?
       alert = 'I need a <strong>username</strong> to enroll a user, silly.'
-      redirect_to [@course, @section], alert: alert
-      return
+      redirect_to [@course, @section], alert: alert and return
     end
 
     user = User.find_or_create(username: params[:username])
+
+    if user.enrolled? section: @section
+      notice = "The user <strong>#{user.username}</strong> is already enrolled."
+      redirect_to [@course, @section], notice: notice and return
+    end
+
     if user
       if @section.is_full? && @section.wait_list_user!(user)
         notice = "<strong>#{user.display_name}</strong>" \
@@ -83,7 +88,7 @@ class SectionsController < ApplicationController
         alert = "There was a problem enrolling" \
                 " <strong>#{user.display_name}</strong>" \
                 " in <strong>#{@course.title}</strong>"
-        redirect_to [@course, @section], notice: alert
+        redirect_to [@course, @section], alert: alert
       end
     else
       alert = "Could not find or create <strong>'#{params[:username]}'</strong>"
@@ -112,8 +117,7 @@ class SectionsController < ApplicationController
   def drop_user
     if params[:user_id].empty?
       alert = 'I need a <strong>user_id</strong> to drop a user, silly.'
-      redirect_to [@course, @section], alert: alert
-      return
+      redirect_to [@course, @section], alert: alert and return
     end
 
     user = User.find(params[:user_id])
@@ -131,8 +135,7 @@ class SectionsController < ApplicationController
   def mark_completed
     if params[:user_id].empty?
       alert = 'I need a <strong>user_id</strong> to mark a user for completion, silly.'
-      redirect_to [@course, @section], alert: alert
-      return
+      redirect_to [@course, @section], alert: alert and return
     end
 
     user = User.find(params[:user_id])
@@ -150,8 +153,7 @@ class SectionsController < ApplicationController
   def mark_no_show
     if params[:user_id].empty?
       alert = 'I need a <strong>user_id</strong> to mark a user as a no-show, silly.'
-      redirect_to [@course, @section], alert: alert
-      return
+      redirect_to [@course, @section], alert: alert and return
     end
 
     user = User.find(params[:user_id])
@@ -166,8 +168,7 @@ class SectionsController < ApplicationController
   def reset_status
     if params[:user_id].empty?
       alert = 'I need a <strong>user_id</strong> to reset a users status, silly.'
-      redirect_to [@course, @section], alert: alert
-      return
+      redirect_to [@course, @section], alert: alert and return
     end
 
     user = User.find(params[:user_id])

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -63,7 +63,11 @@ class SectionsController < ApplicationController
   end
 
   def enroll_user
-    redirect_to [@course, @section] unless params[:username].present?
+    if params[:username].empty?
+      alert = 'I need a <strong>username</strong> to enroll a user, silly.'
+      redirect_to [@course, @section], alert: alert
+      return
+    end
 
     user = User.find_or_create(username: params[:username])
     if user
@@ -106,7 +110,11 @@ class SectionsController < ApplicationController
   end
 
   def drop_user
-    redirect_to [@course, @section] unless params[:user_id].present?
+    if params[:user_id].empty?
+      alert = 'I need a <strong>user_id</strong> to drop a user, silly.'
+      redirect_to [@course, @section], alert: alert
+      return
+    end
 
     user = User.find(params[:user_id])
     if user
@@ -121,7 +129,11 @@ class SectionsController < ApplicationController
   end
 
   def mark_completed
-    redirect_to [@course, @section] unless params[:user_id].present?
+    if params[:user_id].empty?
+      alert = 'I need a <strong>user_id</strong> to mark a user for completion, silly.'
+      redirect_to [@course, @section], alert: alert
+      return
+    end
 
     user = User.find(params[:user_id])
     if user
@@ -136,7 +148,11 @@ class SectionsController < ApplicationController
   end
 
   def mark_no_show
-    redirect_to [@course, @section] unless params[:user_id].present?
+    if params[:user_id].empty?
+      alert = 'I need a <strong>user_id</strong> to mark a user as a no-show, silly.'
+      redirect_to [@course, @section], alert: alert
+      return
+    end
 
     user = User.find(params[:user_id])
     if user
@@ -148,7 +164,11 @@ class SectionsController < ApplicationController
   end
 
   def reset_status
-    redirect_to [@course, @section] unless params[:user_id].present?
+    if params[:user_id].empty?
+      alert = 'I need a <strong>user_id</strong> to reset a users status, silly.'
+      redirect_to [@course, @section], alert: alert
+      return
+    end
 
     user = User.find(params[:user_id])
     if user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -47,7 +47,7 @@ class Ability
         # and mark folks as a no-show for a section
         can :mark_no_show, Section, instructor_id: @user.id
         # and and reset the state
-        can :reset_state, Section, instructor_id: @user.id
+        can :reset_status, Section, instructor_id: @user.id
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -109,6 +109,11 @@ class User < ActiveRecord::Base
     enrollment = enrollment_for(options)
     enrollment.present? && enrollment.completed?
   end
+  
+  def no_show?(options = {})
+    enrollment = enrollment_for(options)
+    enrollment.present? && enrollment.no_show?
+  end
 
   def current_enrollments
     enrollments.select do |enrollment|

--- a/db/migrate/20150901190029_add_unique_user_section_to_enrollments.rb
+++ b/db/migrate/20150901190029_add_unique_user_section_to_enrollments.rb
@@ -1,0 +1,5 @@
+class AddUniqueUserSectionToEnrollments < ActiveRecord::Migration
+  def change
+    add_index :enrollments, [:section_id, :user_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150828162410) do
+ActiveRecord::Schema.define(version: 20150901190029) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20150828162410) do
     t.boolean  "waiting",        default: false
     t.boolean  "no_show",        default: false
   end
+
+  add_index "enrollments", ["section_id", "user_id"], name: "index_enrollments_on_section_id_and_user_id", unique: true, using: :btree
 
   create_table "parts", force: :cascade do |t|
     t.integer  "section_id"

--- a/test/controllers/sections_controller_test.rb
+++ b/test/controllers/sections_controller_test.rb
@@ -92,6 +92,14 @@ class SectionsControllerTest < ActionController::TestCase
     assert_equal "I need a <strong>username</strong> to enroll a user, silly.", flash[:alert]
     assert_redirected_to course_section_path(section.course, section)
   end
+
+  test "users can't be enrolled in sections they are already enrolled in" do
+    section = sections(:canvas101_carrier)
+    sign_in users(:admin)
+    post :enroll_user, id: section, course_id: section.course, username: users(:george).username
+    assert_equal "The user <strong>#{users(:george).username}</strong> is already enrolled.", flash[:notice]
+    assert_redirected_to course_section_path(section.course, section)
+  end
   
   test "drop user with empty user id redirects to course section page" do
     section = sections(:canvas113_rose)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -28,6 +28,26 @@ class UserTest < ActiveSupport::TestCase
     assert !user.instructing?(:course => courses(:canvas113))
   end
 
+  test "user knows if they completed a course" do
+    user = users(:george)
+    course = courses(:canvas101)
+    assert_not user.completed? course: course
+
+    enrollment = user.enrollment_for course: course
+    enrollment.completed!
+    assert user.completed? course: course
+  end
+
+  test "user knows if they no-showed a course" do
+    user = users(:george)
+    course = courses(:canvas101)
+    assert_not user.no_show? course: course
+
+    enrollment = user.enrollment_for course: course
+    enrollment.no_show!
+    assert user.no_show? course: course
+  end
+
   test "has scope for instructors" do
     instructors = User.instructors
     assert_includes instructors, users(:instructor),


### PR DESCRIPTION
Cleaned up the `enroll_user` action to prevent 'double render' errors when
you submit without providing a username.  Also added a guard in the action,
and unique index in the database to prevent duplicate enrollments. (the model
handles uniqueness, but the controller action wasn't giving a good error
message, just that there was a problem) so I added a specific check and gave
an informative message.

Also added tests for some of the other section controller actions that behave
like enroll_user, e.g. drop_user, mark_completed, and mark_no_show